### PR TITLE
fix: fix 2025.3 slash search issue

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -9,7 +9,6 @@
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
-            <option value="$PROJECT_DIR$/IdeaVIM" />
           </set>
         </option>
       </GradleProjectSettings>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,77 +1,68 @@
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
-
-fun properties(key: String) = providers.gradleProperty(key)
-fun environment(key: String) = providers.environmentVariable(key)
+import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 
 plugins {
     id("java") // Java support
     alias(libs.plugins.kotlin) // Kotlin support
-    alias(libs.plugins.gradleIntelliJPlugin) // Gradle IntelliJ Plugin
+    alias(libs.plugins.intelliJPlatform) // IntelliJ Platform Gradle Plugin
     alias(libs.plugins.changelog) // Gradle Changelog Plugin
     alias(libs.plugins.qodana) // Gradle Qodana Plugin
     alias(libs.plugins.kover) // Gradle Kover Plugin
 }
 
-group = properties("pluginGroup").get()
-version = properties("pluginVersion").get()
+group = providers.gradleProperty("pluginGroup").get()
+version = providers.gradleProperty("pluginVersion").get()
+
+// Set the JVM language level used to build the project.
+kotlin {
+    jvmToolchain(21)
+}
 
 // Configure project's dependencies
 repositories {
     mavenCentral()
+
+    // IntelliJ Platform Gradle Plugin Repositories Extension - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-repositories-extension.html
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
 
-// Dependencies are managed with Gradle version catalog - read more: https://docs.gradle.org/current/userguide/platforms.html#sub:version-catalog
+// Dependencies are managed with Gradle version catalog - read more: https://docs.gradle.org/current/userguide/version_catalogs.html
 dependencies {
-//    implementation(libs.annotations)
-}
+    testImplementation(libs.junit)
+    testImplementation(libs.opentest4j)
 
-// Set the JVM language level used to build the project.
-kotlin {
-    jvmToolchain(17)
-}
+    // IntelliJ Platform Gradle Plugin Dependencies Extension - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html
+    intellijPlatform {
+        intellijIdea(providers.gradleProperty("platformVersion"))
 
-// Configure Gradle IntelliJ Plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
-intellij {
-    pluginName = properties("pluginName")
-    version = properties("platformVersion")
-    type = properties("platformType")
+        // Plugin Dependencies. Uses `platformBundledPlugins` property from the gradle.properties file for bundled IntelliJ Platform plugins.
+        bundledPlugins(providers.gradleProperty("platformBundledPlugins").map { it.split(',') })
 
-    // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
-    plugins = properties("platformPlugins").map { it.split(',').map(String::trim).filter(String::isNotEmpty) }
-}
+        // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file for plugin from JetBrains Marketplace.
+        plugins(providers.gradleProperty("platformPlugins").map { it.split(',') })
 
-// Configure Gradle Changelog Plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
-changelog {
-    groups.empty()
-    repositoryUrl = properties("pluginRepositoryUrl")
-}
+        // Module Dependencies. Uses `platformBundledModules` property from the gradle.properties file for bundled IntelliJ Platform modules.
+        bundledModules(providers.gradleProperty("platformBundledModules").map { it.split(',') })
 
-// Configure Gradle Kover Plugin - read more: https://github.com/Kotlin/kotlinx-kover#configuration
-koverReport {
-    defaults {
-        xml {
-            onCheck = true
-        }
+        testFramework(TestFrameworkType.Platform)
     }
 }
 
-tasks {
-    wrapper {
-        gradleVersion = properties("gradleVersion").get()
-    }
-
-    patchPluginXml {
-        version = properties("pluginVersion")
-        sinceBuild = properties("pluginSinceBuild")
-        untilBuild = properties("pluginUntilBuild")
+// Configure IntelliJ Platform Gradle Plugin - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-extension.html
+intellijPlatform {
+    pluginConfiguration {
+        name = providers.gradleProperty("pluginName")
+        version = providers.gradleProperty("pluginVersion")
 
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
-        pluginDescription = providers.fileContents(layout.projectDirectory.file("README.md")).asText.map {
+        description = providers.fileContents(layout.projectDirectory.file("README.md")).asText.map {
             val start = "<!-- Plugin description -->"
             val end = "<!-- Plugin description end -->"
 
-            with (it.lines()) {
+            with(it.lines()) {
                 if (!containsAll(listOf(start, end))) {
                     throw GradleException("Plugin description section not found in README.md:\n$start ... $end")
                 }
@@ -81,7 +72,7 @@ tasks {
 
         val changelog = project.changelog // local variable for configuration cache compatibility
         // Get the latest available change notes from the changelog file
-        changeNotes = properties("pluginVersion").map { pluginVersion ->
+        changeNotes = providers.gradleProperty("pluginVersion").map { pluginVersion ->
             with(changelog) {
                 renderItem(
                     (getOrNull(pluginVersion) ?: getUnreleased())
@@ -91,30 +82,77 @@ tasks {
                 )
             }
         }
+
+        ideaVersion {
+            sinceBuild = providers.gradleProperty("pluginSinceBuild")
+        }
     }
 
-    // Configure UI tests plugin
-    // Read more: https://github.com/JetBrains/intellij-ui-test-robot
-    runIdeForUiTests {
-        systemProperty("robot-server.port", "8082")
-        systemProperty("ide.mac.message.dialogs.as.sheets", "false")
-        systemProperty("jb.privacy.policy.text", "<!--999.999-->")
-        systemProperty("jb.consents.confirmation.enabled", "false")
+    signing {
+        certificateChain = providers.environmentVariable("CERTIFICATE_CHAIN")
+        privateKey = providers.environmentVariable("PRIVATE_KEY")
+        password = providers.environmentVariable("PRIVATE_KEY_PASSWORD")
     }
 
-    signPlugin {
-        certificateChain = environment("CERTIFICATE_CHAIN")
-        privateKey = environment("PRIVATE_KEY")
-        password = environment("PRIVATE_KEY_PASSWORD")
-    }
-
-    publishPlugin {
-        dependsOn("patchChangelog")
-        token = environment("PUBLISH_TOKEN")
+    publishing {
+        token = providers.environmentVariable("PUBLISH_TOKEN")
         // The pluginVersion is based on the SemVer (https://semver.org) and supports pre-release labels, like 2.1.7-alpha.3
         // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
-        // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
-        channels = properties("pluginVersion").map { listOf(it.substringAfter('-', "").substringBefore('.').ifEmpty { "default" }) }
+        // https://plugins.jetbrains.com/docs/intellij/publishing-plugin.html#specifying-a-release-channel
+        channels = providers.gradleProperty("pluginVersion").map { listOf(it.substringAfter('-', "").substringBefore('.').ifEmpty { "default" }) }
+    }
+
+    pluginVerification {
+        ides {
+            recommended()
+        }
     }
 }
 
+// Configure Gradle Changelog Plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
+changelog {
+    groups.empty()
+    repositoryUrl = providers.gradleProperty("pluginRepositoryUrl")
+}
+
+// Configure Gradle Kover Plugin - read more: https://kotlin.github.io/kotlinx-kover/gradle-plugin/#configuration-details
+kover {
+    reports {
+        total {
+            xml {
+                onCheck = true
+            }
+        }
+    }
+}
+
+tasks {
+    wrapper {
+        gradleVersion = providers.gradleProperty("gradleVersion").get()
+    }
+
+    publishPlugin {
+        dependsOn(patchChangelog)
+    }
+}
+
+intellijPlatformTesting {
+    runIde {
+        register("runIdeForUiTests") {
+            task {
+                jvmArgumentProviders += CommandLineArgumentProvider {
+                    listOf(
+                        "-Drobot-server.port=8082",
+                        "-Dide.mac.message.dialogs.as.sheets=false",
+                        "-Djb.privacy.policy.text=<!--999.999-->",
+                        "-Djb.consents.confirmation.enabled=false",
+                    )
+                }
+            }
+
+            plugins {
+                robotServerPlugin()
+            }
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,22 +7,31 @@ pluginName = VimMulticursor
 pluginVersion = 1.3.2
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
-platformType = IC
-platformVersion = 2024.2
+platformVersion = 2025.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins = IdeaVIM:2.16.0
+platformPlugins = IdeaVIM:2.28.0
 
-pluginSinceBuild = 242
+# Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
+pluginSinceBuild = 252
 
 # Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
-javaVersion = 17
+javaVersion = 21
+
+# Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
+kotlin.stdlib.default.dependency = false
+
+# Example: platformBundledPlugins = com.intellij.java
+platformBundledPlugins =
+# Example: platformBundledModules = intellij.spellchecker
+platformBundledModules =
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 8.6
+gradleVersion = 9.2.1
 
-# Opt-out flag for bundling Kotlin standard library.
-# See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.
-# suppress inspection "UnusedProperty"
-kotlin.stdlib.default.dependency = false
+# Enable Gradle Configuration Cache -> https://docs.gradle.org/current/userguide/configuration_cache.html
+org.gradle.configuration-cache = true
+
+# Enable Gradle Build Cache -> https://docs.gradle.org/current/userguide/build_cache.html
+org.gradle.caching = true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,20 +1,22 @@
 [versions]
 # libraries
-annotations = "24.1.0"
+junit = "4.13.2"
+opentest4j = "1.3.0"
 
 # plugins
-kotlin = "1.9.23"
-changelog = "2.2.0"
-gradleIntelliJPlugin = "1.17.2"
-qodana = "2023.3.1"
-kover = "0.7.6"
+changelog = "2.5.0"
+intelliJPlatform = "2.10.5"
+kotlin = "2.2.21"
+kover = "0.9.3"
+qodana = "2025.2.2"
 
 [libraries]
-annotations = { group = "org.jetbrains", name = "annotations", version.ref = "annotations" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+opentest4j = { group = "org.opentest4j", name = "opentest4j", version.ref = "opentest4j" }
 
 [plugins]
 changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }
-gradleIntelliJPlugin = { id = "org.jetbrains.intellij", version.ref = "gradleIntelliJPlugin" }
+intelliJPlatform = { id = "org.jetbrains.intellij.platform", version.ref = "intelliJPlatform" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 qodana = { id = "org.jetbrains.qodana", version.ref = "qodana" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/qodana.yml
+++ b/qodana.yml
@@ -3,7 +3,7 @@
 
 version: 1.0
 linter: jetbrains/qodana-jvm-community:latest
-projectJDK: "17"
+projectJDK: "21"
 profile:
   name: qodana.recommended
 exclude:

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
 rootProject.name = "VimMulticursor"
 
-include("IdeaVIM")
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}

--- a/src/main/kotlin/com/github/dankinsoid/multicursor/VimMulticursor.kt
+++ b/src/main/kotlin/com/github/dankinsoid/multicursor/VimMulticursor.kt
@@ -45,7 +45,7 @@ class VimMulticursor : VimExtension {
 		mapToFunctionAndProvideKeys("a\"") { MultiselectTextObjectHandler("\"", "\"", false, it) }
 		mapToFunctionAndProvideKeys("a'") { MultiselectTextObjectHandler("'", "'", false, it) }
 		mapToFunctionAndProvideKeys("a`") { MultiselectTextObjectHandler("`", "`", false, it) }
-		
+
 		// Inside versions
 		mapToFunctionAndProvideKeys("ib") { MultiselectTextObjectHandler("(", ")", true, it) }
 		mapToFunctionAndProvideKeys("iB") { MultiselectTextObjectHandler("{", "}", true, it) }
@@ -71,21 +71,21 @@ class VimMulticursor : VimExtension {
 		override fun execute(editor: Editor, context: DataContext) {
 			val offset = editor.caretModel.primaryCaret.offset
 			val text = editor.document.charsSequence
-			
+
 			// Find word boundaries
 			var start = offset
 			var end = offset
-			
+
 			// Find start of word
 			while (start > 0 && text[start - 1].isLetterOrDigit()) {
 				start--
 			}
-			
+
 			// Find end of word
 			while (end < text.length && text[end].isLetterOrDigit()) {
 				end++
 			}
-			
+
 			// Add carets at word boundaries
 			editor.setCarets(sequenceOf(IntRange(start, start), IntRange(end, end)), false)
 		}
@@ -98,6 +98,9 @@ class VimMulticursor : VimExtension {
 		override fun execute(editor: Editor, context: DataContext) {
 			val panel = ExEntryPanelService().createPanel(editor.vim, context.vim, "/", "")
 			ModalEntry.activate(editor.vim) { key: KeyStroke ->
+				if (key.keyChar == '\n') {
+					return@activate true
+				}
 				return@activate when (key.keyCode) {
 					KeyEvent.VK_ESCAPE -> {
 						panel.deactivate(refocusOwningEditor = true, resetCaret = true)
@@ -134,7 +137,7 @@ class VimMulticursor : VimExtension {
 		override fun execute(editor: Editor, context: DataContext) {
 			val offset = editor.caretModel.primaryCaret.offset
 			val text = editor.document.charsSequence
-			
+
 			// Define all possible pairs
 			val pairs = listOf(
 				"(" to ")",
@@ -144,11 +147,11 @@ class VimMulticursor : VimExtension {
 				"'" to "'",
 				"`" to "`"
 			)
-			
+
 			// Find the closest pair
 			var closestRange: Pair<IntRange, IntRange>? = null
 			var minDistance = Int.MAX_VALUE
-			
+
 			for ((openDelim, closeDelim) in pairs) {
 				val range = findPairedRange(text, offset, openDelim, closeDelim)
 				if (range != null) {
@@ -164,7 +167,7 @@ class VimMulticursor : VimExtension {
 					}
 				}
 			}
-			
+
 			if (closestRange != null) {
 				var (start, end) = closestRange
 				if (inside) {
@@ -209,7 +212,7 @@ class VimMulticursor : VimExtension {
 			val text = editor.document.charsSequence
 			val selections = editor.selections()
 			val ranges = mutableListOf<IntRange>()
-			
+
 			if (selections.count() > 0) {
 				// If there are selections, only search within them
 				for (selection in selections) {
@@ -227,7 +230,7 @@ class VimMulticursor : VimExtension {
 			} else {
 				// No selections, search in entire document
 				val caretOffset = editor.caretModel.primaryCaret.offset
-				
+
 				// Search forward from caret
 				var pos = caretOffset
 				while (pos < text.length) {
@@ -237,7 +240,7 @@ class VimMulticursor : VimExtension {
 					}
 					pos++
 				}
-				
+
 				// Search backward from caret
 				pos = caretOffset - 1
 				while (pos >= 0) {
@@ -248,7 +251,7 @@ class VimMulticursor : VimExtension {
 					pos--
 				}
 			}
-			
+
 			if (ranges.isNotEmpty()) {
 				editor.setCarets(ranges.asSequence(), select)
 			}


### PR DESCRIPTION
- Update to latest [intellij-platform-plugin-template](https://github.com/JetBrains/intellij-platform-plugin-template)
- Fix the issue where the / search functionality is not working in 2025.3

When using the `mc/` or `ms/` search functionality in the latest version of IdeaVim + IDEA, pressing Enter triggers both `\n` and `Enter` events. In the new version, `\n` is interpreted as a space, causing a space character to appear after the search term, which leads to the failure of inserting the cursor.